### PR TITLE
Accept AbstractVector for twiss `at` keyword (Python support)

### DIFF
--- a/src/twiss.jl
+++ b/src/twiss.jl
@@ -33,7 +33,7 @@ Callbacks are applied AFTER the step. Therefore,
 # ========== STEP 1 ==================================
 # Resolve number of steps, step indicies, type of s, base columns, etc.
 
-function _twiss_1(bl::Beamline, at::Vector)
+function _twiss_1(bl::Beamline, at::AbstractVector)
   at_idxs = filter(x->x isa Integer, at)
   at_eles = filter(x->x isa LineElement, at)
   at_ranges = filter(x->x isa Tuple, at)
@@ -644,7 +644,7 @@ function twiss(
   de_moivre::Bool                             = false,
   normalizing_map::Bool                       = false,
   RDTs::Bool                                  = false,
-  at::Union{Colon, Vector}                    = :,
+  at::Union{Colon, AbstractVector}            = :,
   in_body_coordinates::Bool                   = false, 
 
   # Initial input:


### PR DESCRIPTION
Part of the Python-interface work for #76.

## What

Generalizes the `at` keyword of `twiss` (and the internal `_twiss_1`) from `Vector` to `AbstractVector`:

```julia
- at::Union{Colon, Vector}    = :,
+ at::Union{Colon, AbstractVector} = :,
```

## Why

So that array types other than `Vector` are accepted — in particular a `PyArray` handed over from Python via `PythonCall`/`juliacall`. This is exactly the "type generalization instead of `Vector`" change called for in #76, and keeps SciBmad.jl from having to depend on PythonCall.

## Notes / scope

- Pure type generalization — no behavior change for existing `Vector`/`Colon` callers.
- A raw `PyList` of *element* objects still needs its items converted to Julia types before the `isa Integer` / `isa LineElement` / `isa Tuple` filters in `_twiss_1` match; a numeric `PyArray` (whose elements materialize as Julia values) works directly. Element-list conversion is handled Python-side in the `scibmad` package today.

## Testing

Verified via juliacall that `twiss(bl; at=<SubArray>)` (an `AbstractVector` that is not a `Vector`) runs, where it previously raised a `MethodError`. Opened as a **draft** — I could not run the full SciBmad.jl CI locally.