### PR TITLE
Fix docs PR preview deploy and cleanup

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -78,11 +78,12 @@ jobs:
         with:
           source-dir: ./gh-pages
       - name: Deploy documentation
-        uses: peaceiris/actions-gh-pages@v4
+        uses: JamesIves/github-pages-deploy-action@v4
         if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./gh-pages
+          folder: ./gh-pages
+          clean-exclude: pr-preview/ # keep live previews for still-open PRs
+          force: false # retry instead of clobbering a concurrent preview deploy
       - name: Run doctests
         shell: julia --project=docs --color=yes {0}
         run: |

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -7,7 +7,9 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      pull-requests: write # needed to update the preview comment on the PR
     steps:
+      - uses: actions/checkout@v7 # pr-preview-action runs git in the workspace
       - name: Remove PR preview
         uses: rossjrw/pr-preview-action@v1
         with:


### PR DESCRIPTION
## Problem

The cleanup workflow invokes `pr-preview-action` without checking out the repository first, so the action's very first `git` call fails ([run 32419788891](https://github.com/bmad-sim/SciBmad.jl/actions/runs/32419788891)):

```
[command]/usr/bin/git config user.name DavidSagan
fatal: not in a git directory
##[error]There was an error initializing the repository: The process '/usr/bin/git' failed with exit code 128
```

It has never once succeeded — `git log origin/gh-pages --grep='Remove preview'` returns nothing.

Previews were disappearing anyway, but for the wrong reason: `peaceiris/actions-gh-pages` republishes `./gh-pages` as the *entire* branch content on every push to `main`, wiping `pr-preview/` wholesale. That masked the broken cleanup, and also meant an open PR's preview link broke whenever anything merged. PR #90's preview had to be redeployed for exactly this reason.

## Changes

**`docs-preview-cleanup.yml`** — add `actions/checkout@v7`, and `pull-requests: write` so the post-removal comment update can run.

**`CI.yml`** — swap the main deploy to `JamesIves/github-pages-deploy-action@v4` with `clean-exclude: pr-preview/`, which is what `pr-preview-action`'s README recommends for exactly this interaction. The root is still cleaned (so renamed pages don't accumulate as orphans), but live previews survive. `force: false` makes a concurrent preview deploy retry instead of getting clobbered.

Checked, not assumed:

- `branch` already defaults to `gh-pages` and `token` to the job's `github.token`; the job grants `contents: write`.
- `clean` defaults to `true`, so root cleanup is preserved.
- `.nojekyll` is emitted by `sphinx.ext.githubpages` (`docs/src/conf.py:14`) into the build output and copied through by `docs/build.py:55` — it does not come from the deploy action, so it survives the swap. Losing it would have made Jekyll skip `_static`, `_sources`, and `_images`.

## Verification

The deploy step only fires on push to `main` or a tag, so it cannot be exercised from this PR — that half lands unverified. After merge:

- `pr-preview/pr-90/` should still exist on `gh-pages` (the property the old config broke).
- Closing any PR should produce a `Remove preview for PR N` commit.

Note the first deploy on `main` will delete stale root files left over from earlier docs layouts, since `clean: true` now actually applies to them. That's intended and recoverable from branch history, but expect a large delete count on that run.

## Not addressed

- **No `concurrency` group.** Closing a PR while its docs build is in flight can let the deploy re-create a preview after cleanup removed it. The fix is a `concurrency: preview-<ref>` group shared across both jobs.
- **Fork PRs.** `pull_request` gives forks a read-only token, so neither deploy nor cleanup can write to `gh-pages` from a fork. Everything so far is same-repo; fixing it means `pull_request_target` and its security tradeoffs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ueLe41QwBh52oa53XD1hp
