### PR TITLE
Fix UndefVarError for `ele` in _twiss_assemble_locations

### DIFF
--- a/src/twiss/twiss.jl
+++ b/src/twiss/twiss.jl
@@ -433,10 +433,10 @@ function _twiss_assemble_locations(bl::Beamline, at::Vector)
   s = typeof(scur).(stmp)
 
   include_start = any(x->x[1]<=0<=x[2], at_ranges) || any(x->x==1, at_idxs) || any(at_eles) do x
-    x == bl.line[1] || (haskey(getfield(ele, :pdict), InheritParams) ? x == (getfield(bl.line[1], :pdict)[InheritParams].parent) : false)
+    x == bl.line[1] || (haskey(getfield(bl.line[1], :pdict), InheritParams) ? x == (getfield(bl.line[1], :pdict)[InheritParams].parent) : false)
   end
   include_end = any(x->x[1]<=scur<=x[2], at_ranges) || any(x->x==length(bl.line), at_idxs) || any(at_eles) do x
-    x == bl.line[end] || (haskey(getfield(ele, :pdict), InheritParams) ? x == (getfield(bl.line[end], :pdict)[InheritParams].parent) : false)
+    x == bl.line[end] || (haskey(getfield(bl.line[end], :pdict), InheritParams) ? x == (getfield(bl.line[end], :pdict)[InheritParams].parent) : false)
   end
 
   return s, names, kinds, idxs, step_save, include_start, include_end


### PR DESCRIPTION
`twiss(bl; at=...)` fails with:

```
UndefVarError: `ele` not defined in `SciBmad`
  [1] (::SciBmad.var"#_twiss_assemble_locations##20#...")(x::LineElement)
    @ SciBmad src/twiss/twiss.jl:436
```

The `include_start` / `include_end` closures in `_twiss_assemble_locations`
reference `ele`, the loop variable of the `for ele in bl.line` loop that has
already ended by that point, so the name is out of scope.

The `haskey` guard should test the same element the ternary's true branch
dereferences — `bl.line[1]` for `include_start` and `bl.line[end]` for
`include_end` — matching the equivalent check inside the loop at line 414.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DhNK34A2d5MfzZXifkKHH
