### PR TITLE
Skip precompile workload when code coverage is enabled

### DIFF
--- a/src/SciBmad.jl
+++ b/src/SciBmad.jl
@@ -58,6 +58,12 @@ include("dynamic_aperture.jl")
 include("experimental/Experimental.jl")
 include("utils.jl")
 
+# Precompiling this workload under code-coverage instrumentation is
+# pathologically expensive: on Julia 1.12 it runs for over 20 minutes and
+# several GB before finishing, which takes the CI runner down before the test
+# suite ever starts. The workload exists purely to cut first-call latency for
+# users, so skip it when Julia is generating coverage data.
+if Base.JLOptions().code_coverage == 0
 @setup_workload begin
   
   @compile_workload begin   
@@ -146,5 +152,6 @@ include("utils.jl")
     grad(tw.dh2000[1])
   end
 end
+end # if Base.JLOptions().code_coverage == 0
 
 end


### PR DESCRIPTION
## The failure

The `Julia 1` CI job has been failing since #96 with no test output at all —
the log goes silent right after

```
Precompiling for configuration --code-coverage=@/home/runner/work/SciBmad.jl/SciBmad.jl ...
```

and 24 minutes later the runner dies:

```
##[error]The runner has received a shutdown signal.
[2410] signal 15: Terminated
##[error]The operation was canceled.
```

`timeout-minutes: 60` is never reached, and `Julia lts` (1.10.12) passes the
same suite in ~9 minutes.

## Cause

Bisected between the last green run (`251ed06`) and the first red one
(`0435d93`) down to **bbecc6c**, which removed `__precompile__(false)` from
`src/SciBmad.jl` and at the same time roughly tripled the `@compile_workload`
(spin tracking, ten `twiss` variants across `order=2` / `chrom=2` / `spin`, and
a parametric normal-form section with `Descriptor`s up to order 3 in 8
variables).

`Pkg.test` precompiles the package under its own configuration, which includes
`--code-coverage=@<pkgdir> --check-bounds=yes`. Catching the stuck worker
locally confirms it is SciBmad's own precompile:

```
julia -C native ... --code-coverage=@.../SciBmad --check-bounds=yes
      --output-o ~/.julia/compiled/v1.12/SciBmad/jl_IOLsB2 ...
```

Measured on Julia 1.12.7 (same as CI) with `Pkg.test(coverage=true)` and a
fresh resolve:

| tree | result | wall | peak RSS |
| --- | --- | --- | --- |
| `965e050` (parent of bbecc6c) | pass | 195 s | 720 MB |
| `4027f1a` + `__precompile__(false)` restored | pass | 193 s | 734 MB |
| `4027f1a`, precompile on, pre-bbecc6c workload | pass | 1125 s | 716 MB |
| `4027f1a` as-is | **never finished** — killed at 21 min, 12+ of them inside the coverage precompile | — | ~6.5 GB |

Both halves of bbecc6c contribute: enabling precompilation alone takes the run
from 195 s to 1125 s, and the enlarged workload pushes it past the point where
it finishes at all. Julia 1.10 precompiles the same workload fine, which is why
only the `Julia 1` job fails.

## Fix

The workload exists only to cut first-call latency for users, so it is pure
overhead during a coverage run. Guard it on `Base.JLOptions().code_coverage`,
which is `0` for a normal load and non-zero under `--code-coverage`.

Verified: with the guard, `Pkg.test(coverage=true)` on 1.12.7 completes and the
suite passes in 2m57.5s (19 pass, 4 broken) — the same result as the lts job.

The `if` is added without re-indenting the 88-line block it wraps, to keep the
diff to the guard itself.

Independent of #99, which only inherits this failure from `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012DhNK34A2d5MfzZXifkKHH
