### PR TITLE
Document the properties of the Twiss struct returned by twiss

### DIFF
--- a/src/twiss/twiss.jl
+++ b/src/twiss/twiss.jl
@@ -190,6 +190,41 @@ linear dispersion).
 - `as`     : (Nonlinear) spin normalizing map
 - `h<ijkl>`   : The "ijkl" resonance driving term/detune coefficient/Bengtsson monomial for the coasting beam case
 - `h<ijklmn>` : The "ijklmn" resonance driving term/detune coefficient/Bengtsson monomial including longitudinal oscillations
+
+## Properties of the returned `Twiss` struct
+
+The returned `Twiss` struct has two fields, each accessible as a property:
+
+- `summ` : A `TwissSummary` containing the lattice-wide (s-independent) quantities listed below
+- `df`   : The `DataFrame` of s-dependent quantities, with one row per saved location and one 
+    column for each entry of `base_cols` and `cols`
+
+As a convenience, every summary quantity and every dataframe column may also be accessed directly 
+as a property of the `Twiss` struct itself. E.g., for `tw = twiss(bl)`, `tw.q1` is equivalent to 
+`tw.summ.q1`, and `tw.beta1` is equivalent to `tw.df.beta1`. `propertynames(tw)` lists every 
+property available for that particular `twiss` call.
+
+The summary properties, all evaluated for the full lattice, are:
+
+- `q1`     : Horizontal-like tune, equal to the total `phi1` phase advance in units of [2π]
+- `q2`     : Vertical-like tune, equal to the total `phi2` phase advance in units of [2π]
+- `q3`     : Longitudinal-like (synchrotron) tune in units of [2π]. Only present if the beam is 
+    not coasting (e.g. `rf_on=true` with RF cavities in the lattice)
+- `etac`   : Phase slip factor η_c, the relative change of the revolution period per unit δ
+- `alphac` : Momentum compaction factor α_c, the relative change of the closed orbit path length 
+    per unit δ
+- `qspin`  : Spin tune in units of [2π]. Only present if `spin=true`
+- `damp1`  : Damping decrement of mode 1 per turn, i.e. the natural logarithm of the mode 1 
+    amplitude reduction factor per turn. Only present if radiation damping is included
+- `damp2`  : Damping decrement of mode 2 per turn. Only present if radiation damping is included
+- `damp3`  : Damping decrement of mode 3 per turn. Only present if radiation damping is included
+
+Summary quantities which are amplitude- and/or parameter-dependent (e.g. with `order > 1`, or with 
+parameters in the GTPSA `Descriptor`) are returned as `AmplitudeDependentValue`s, from which the 
+individual terms may be obtained using the actions `J1`, `J2`, `J3` (or `delta` in place of `J3` for 
+a coasting beam) as keyword arguments. E.g. `tw.q1[J1=1]` gives the coefficient of J₁ in the 
+amplitude expansion of the horizontal-like tune, and `tw.q1[delta=1]` gives the linear chromaticity 
+of a coasting beam.
 """
 function twiss(
   bl::Beamline; 


### PR DESCRIPTION
Adds a **Properties of the returned `Twiss` struct** section to the extended help of `twiss`, so `??twiss` documents not just the available `cols` but also what comes back.

The new section covers:

- The two fields — `summ` (the `TwissSummary` of lattice-wide quantities) and `df` (the s-dependent `DataFrame`) — and the fact that every summary quantity and dataframe column is also reachable directly off the struct (`tw.q1`, `tw.beta1`), with `propertynames(tw)` listing them for a given call.
- Each summary property produced by `_twiss_summ`: `q1`, `q2`, `q3`, `etac`, `alphac`, `qspin`, `damp1`/`damp2`/`damp3`, each with the condition under which it is present (`q3` only for a non-coasting beam, `qspin` only with `spin=true`, `damp*` only with radiation damping).
- A closing note that amplitude/parameter-dependent summary values are returned as `AmplitudeDependentValue`s, indexable with `J1`/`J2`/`J3`/`delta` — e.g. `tw.q1[delta=1]` for the linear chromaticity of a coasting beam.

Documentation only; no functional change.

## Verification

Checked against a small FODO (`pc_ref=18e9`):

| Config | `propertynames(tw.summ)` |
|---|---|
| RF on | `q1, q2, q3, etac, alphac` |
| `rf_on=false` | `q1, q2, etac, alphac` |
| `rf_on=false, spin=true` | `q1, q2, etac, alphac, qspin` |

Also confirmed `tw.q1 == tw.summ.q1`, `tw.beta1 === tw.df.beta1`, that `propertynames(tw)` is the summary keys followed by the dataframe columns, and that `q1` equals `phi1[end]` exactly — which is the basis for the "total `phi1` phase advance in units of [2π]" wording. With `chrom=2`, `tw.q1` is an `AmplitudeDependentValue` and `tw.q1[delta=1]` returns the linear chromaticity, so the example in the docstring runs as written.

`damp1`/`damp2`/`damp3` are the one set of entries not exercised: the damping branch in NonlinearNormalForm's `normal.jl` still hits `error("need to finish")`, so those descriptions are based on reading `damp .= log.(damp)` there and may want a second look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
