### PR TITLE
Fix dynamic_aperture reporting the grid instead of the aperture

### DIFF
--- a/src/dynamic_aperture.jl
+++ b/src/dynamic_aperture.jl
@@ -1,11 +1,25 @@
 """
-    dynamic_aperture(ring::Beamline; kwargs...) -> NTuple{2,Vector{Float64}}
+    dynamic_aperture(ring::Beamline; kwargs...) -> NTuple{2,Matrix{Float64}}
 
-Computes the acceptance of the ring by pushing a polar grid in `x/sig_x` and `y/sig_y` 
-space, for each of the provided `deltas`. Returns a tuple of two vectors defining the 
-first particle loss along the radius for a given angle on the polar grid, where the 
-first index corresponds to the line position in `x/sig_x` or `y/sig_y` space, and the 
-second index corresponds to that in `deltas`.
+Computes the acceptance of the ring by pushing a polar grid in `x/sig_x` and `y/sig_y`
+space, for each of the provided `deltas`. Returns a tuple of two matrices whose first
+index corresponds to the angle on the polar grid and whose second index corresponds to
+the entry in `deltas`.
+
+For each angle the returned value is the **largest sampled amplitude that survived** all
+`n_turns` turns, so the reported acceptance is never larger than the true one. The true
+boundary lies between that amplitude and the next radial sample, i.e. the result carries
+an uncertainty of one radial step: `max_sig_x/(n_r-1)` in `x/sig_x` and `max_sig_y/(n_r-1)`
+in `y/sig_y`. Choose `max_sig_x`, `max_sig_y` and `n_r` so that several radial samples fall
+inside the aperture; the radial step in metres is printed when the scan starts.
+
+Two sentinel values are returned when the grid fails to bracket the aperture, and each
+raises a warning:
+- `NaN` -- even the innermost sampled amplitude was lost, so the grid is too coarse to
+  resolve the aperture at that angle. Reduce `max_sig_x`/`max_sig_y`, or increase `n_r`.
+  `NaN` is also returned for a `delta` whose closed orbit could not survive the tracking.
+- `Inf` -- no sampled amplitude was lost, so the aperture lies beyond the grid. Increase
+  `max_sig_x`/`max_sig_y`.
 
 ## Required Keyword arguments
 - `n_r::Int`: Number of radial points to sample per angle on the polar grid
@@ -63,6 +77,9 @@ function dynamic_aperture(
     track_kwargs... # Get passed to track!
   )
   Base.require_one_based_indexing(deltas)
+  if n_r < 2
+    error("n_r must be at least 2 (got n_r = $n_r): the radial grid holds n_r-1 sampled amplitudes.")
+  end
   if delta_dependent_orbits && emit_3 != 0
     error("delta_dependent_orbits = true, but a nonzero emit_3 was provided. Instead specify sig_pz")
   elseif !delta_dependent_orbits && sig_pz != 0
@@ -121,8 +138,15 @@ function dynamic_aperture(
   thetas = range(theta_lims[1], theta_lims[2], length=n_theta)
   rs = range(0, 1, length=n_r)[2:end]
 
+  # Radial resolution of the scan. The result is only meaningful if several of these steps
+  # fit inside the aperture, so report it up front.
+  dr_x = max_sig_x*sig_x*first(rs)
+  dr_y = max_sig_y*sig_y*first(rs)
+
   n_particles = n_deltas*(1+length(rs)*length(thetas))
   println("Initializing dynamic_aperture with $n_particles particles")
+  println("  sig_x = $sig_x m, sig_y = $sig_y m")
+  println("  radial step = $dr_x m in x, $dr_y m in y")
   v0 = zeros(n_particles, 6)
   v = zeros(n_particles, 6)
   idx_particle = 1
@@ -172,9 +196,15 @@ function dynamic_aperture(
   y_norm_da = zeros(length(thetas), n_deltas)
 
   # Loop thru the thetas, find max for each along r
+  n_unresolved = 0   # innermost sampled amplitude already lost -> grid too coarse
+  n_unbounded  = 0   # nothing lost along the ray -> aperture lies beyond the grid
+  n_co_lost    = 0   # closed orbit itself did not survive
   idx_particle = 1
   for i in LinearIndices(deltas)
       if state[idx_particle] != 0x1
+          n_co_lost += 1
+          x_norm_da[:,i] .= NaN
+          y_norm_da[:,i] .= NaN
           idx_particle += length(thetas)*length(rs)+1
           continue
       end
@@ -194,25 +224,47 @@ function dynamic_aperture(
               end
               
           end
-          
-          if !isnothing(findfirst(t->t != 0x1, state[idx_particle:idx_particle+length(rs)-1]))
-            idx_da = idx_particle-1 + findfirst(t->t != 0x1, state[idx_particle:idx_particle+length(rs)-1])
 
-            # Sanity check:
-            
-            if idx_da-(idx_particle-1) != 1 && state[idx_da-1] != 0x1
-                error("Something went wrong")
-            end
-            
-            x_norm_da[j,i] = v0[idx_da,1]/sig_x
-            y_norm_da[j,i] = v0[idx_da,3]/sig_y
-            idx_particle += length(rs)
+          # The aperture is bracketed by the last surviving sample and the first lost one.
+          # Report the last SURVIVING amplitude: reporting the first LOST one overstates the
+          # acceptance by up to one radial step, and on a grid too coarse to resolve the
+          # aperture it degenerates into reporting the grid itself rather than the machine.
+          idx_first_lost = findfirst(t->t != 0x1, state[idx_particle:idx_particle+length(rs)-1])
+
+          if isnothing(idx_first_lost)
+              n_unbounded += 1
+              x_norm_da[j,i] = Inf
+              y_norm_da[j,i] = Inf
+          elseif idx_first_lost == 1
+              # Nothing survived, not even the innermost ring: the aperture lies somewhere
+              # inside the first radial step and this scan cannot say where.
+              n_unresolved += 1
+              x_norm_da[j,i] = NaN
+              y_norm_da[j,i] = NaN
           else
-            x_norm_da[j,i] = Inf
-            y_norm_da[j,i] = Inf
-            idx_particle += length(rs)
+              idx_da = idx_particle-1 + idx_first_lost - 1
+              x_norm_da[j,i] = v0[idx_da,1]/sig_x
+              y_norm_da[j,i] = v0[idx_da,3]/sig_y
           end
+          idx_particle += length(rs)
       end
+  end
+
+  n_points = length(thetas)*n_deltas
+  if n_co_lost > 0
+      @warn "dynamic_aperture: the closed orbit itself was lost for $n_co_lost of $n_deltas deltas; " *
+            "those columns are returned as NaN."
+  end
+  if n_unresolved > 0
+      @warn "dynamic_aperture: the innermost sampled amplitude was already lost at $n_unresolved of " *
+            "$n_points (angle, delta) points, so the aperture is unresolved there and is reported as NaN. " *
+            "The radial step is $dr_x m in x and $dr_y m in y. Reduce max_sig_x/max_sig_y, or increase " *
+            "n_r, so that several radial samples fall inside the aperture."
+  end
+  if n_unbounded > 0
+      @warn "dynamic_aperture: no sampled amplitude was lost at $n_unbounded of $n_points " *
+            "(angle, delta) points, so the aperture lies beyond the grid and is reported as Inf. " *
+            "Increase max_sig_x/max_sig_y to bracket it."
   end
 
   # output file will have first 6 columns as INITIAL coordinates wrt

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -118,4 +118,65 @@ using Test
         @test isapprox(co.v0[1,5], 0.0; atol=1e-12)
         @test isapprox(co.v0[1,6], 0.0; atol=1e-12)
     end
+
+    @testset "dynamic_aperture grid resolution" begin
+        # A symmetric FODO cell with a known, hard rectangular aperture in x. The cell is
+        # mirror-symmetric, so alpha_1 = 0 at element 1: a particle started at (x0, px=0)
+        # never exceeds |x0| there on later turns, and the aperture in terms of the
+        # starting x0 is exactly the physical limit. That makes the expected answer exact
+        # and independent of the tune, so a handful of turns suffices.
+        a = 0.01
+        function fodo()
+            qf1 = Quadrupole(L=0.25, Kn1= 0.6)
+            d1  = Drift(L=1.0)
+            qd  = Quadrupole(L=0.5,  Kn1=-0.6)
+            d2  = Drift(L=1.0)
+            qf2 = Quadrupole(L=0.25, Kn1= 0.6)
+            qf1.x1_limit = -a
+            qf1.x2_limit =  a
+            qf1.aperture_shape = ApertureShape.Rectangular
+            Beamline([qf1,d1,qd,d2,qf2]; pc_ref=1e9, species_ref=Species("electron"))
+        end
+
+        emit = 1e-8
+        bl = fodo()
+        sig_x = sqrt(twiss(bl, at=[1], cols=["E1"]).E1[1][1,1]*emit)
+
+        # Grid step = a/3.5, so the aperture falls between samples 3 and 4: sample 3
+        # survives, sample 4 is lost.
+        n_r = 12
+        max_sig = (a/3.5)*(n_r-1)/sig_x
+        x, _ = dynamic_aperture(bl; n_r=n_r, n_theta=1, theta_lims=(0,0), deltas=[0.0],
+                                max_sig_x=max_sig, max_sig_y=max_sig,
+                                emit_1=emit, emit_2=emit, n_turns=8)
+
+        # The reported acceptance must be the last SURVIVING sample, and must never exceed
+        # the physical aperture. Reporting the first LOST sample would give 4a/3.5 > a.
+        @test x[1]*sig_x ≈ 3*(a/3.5)
+        @test x[1]*sig_x < a
+
+        # Grid too coarse to resolve the aperture: even the innermost sample is lost, so
+        # the result is NaN rather than a spurious "aperture" of one grid step (issue #115).
+        max_sig_coarse = (2*a)*(n_r-1)/sig_x
+        x_coarse, y_coarse = @test_logs (:warn,) match_mode=:any dynamic_aperture(
+            bl; n_r=n_r, n_theta=1, theta_lims=(0,0), deltas=[0.0],
+            max_sig_x=max_sig_coarse, max_sig_y=max_sig_coarse,
+            emit_1=emit, emit_2=emit, n_turns=8)
+        @test isnan(x_coarse[1])
+        @test isnan(y_coarse[1])
+
+        # Grid entirely inside the aperture: nothing is lost, so the answer is Inf.
+        # Here it is the OUTER radius (max_sig*sig_x), not the step, that must stay below a.
+        max_sig_small = (a/2)/sig_x
+        x_small, y_small = @test_logs (:warn,) match_mode=:any dynamic_aperture(
+            bl; n_r=n_r, n_theta=1, theta_lims=(0,0), deltas=[0.0],
+            max_sig_x=max_sig_small, max_sig_y=max_sig_small,
+            emit_1=emit, emit_2=emit, n_turns=8)
+        @test isinf(x_small[1])
+        @test isinf(y_small[1])
+
+        @test_throws ErrorException dynamic_aperture(
+            bl; n_r=1, n_theta=1, deltas=[0.0], max_sig_x=1.0, max_sig_y=1.0,
+            emit_1=emit, emit_2=emit, n_turns=1)
+    end
 end


### PR DESCRIPTION
Closes #115.

## The bug

`dynamic_aperture` reported the first **lost** radius on the polar grid as the acceptance, with no bisection or refinement:

```julia
idx_da = idx_particle-1 + findfirst(t->t != 0x1, state[...])
x_norm_da[j,i] = v0[idx_da,1]/sig_x
```

That overstates the aperture by up to one radial step. When the grid is too coarse to resolve the aperture at all, it degenerates into reporting the grid itself.

Issue #115 is exactly that degenerate case. With `max_sig_x = 100000` and `n_r = 30`, and σ_x = 32.3 µm, the innermost sampled amplitude is **111 mm** in x — against a true horizontal aperture of ~22 mm. Every sample along θ = 0 is therefore lost, and the reported "aperture" of 111 mm is precisely one radial step. Every feature of the curve in that issue lands on a grid ring. Nothing warned.

The existing sanity check explicitly skipped the one case that would have caught it:

```julia
if idx_da-(idx_particle-1) != 1 && state[idx_da-1] != 0x1
```

`idx_da-(idx_particle-1) == 1` *is* "the innermost sample was already lost".

## Changes

- Report the last **surviving** amplitude, so the result is never larger than the true acceptance. The boundary lies within one radial step above it.
- Return `NaN`, and warn, when even the innermost sample is lost. `NaN` rather than `0` because `0` is a legitimate coordinate — y at θ=0, x at θ=π/2 — and it renders as a gap rather than a spurious point.
- Warn on the existing `Inf` case (nothing lost, aperture beyond the grid), and return `NaN` instead of silently leaving zeros when a delta's closed orbit is itself lost.
- Print σ_x, σ_y and the radial step **in metres** when the scan starts, so the resolution is visible without deriving it.
- Error on `n_r < 2`, which previously threw from `first(rs)` on an empty range.
- Docstring: state the return convention, the one-step uncertainty and both sentinels; correct the return type from vectors to matrices.

The removed `"Something went wrong"` check was unreachable — `findfirst` guarantees every earlier sample is alive.

## Behaviour change

Returned values shift down by up to one radial step. On a well-resolved grid that is negligible; on a coarse one it is the whole point. Reverting just that part while keeping the warnings is a small change if reviewers prefer it.

## Test

New `@testset "dynamic_aperture grid resolution"`: a symmetric FODO cell with a hard rectangular aperture at x = ±10 mm. The cell is mirror-symmetric so α₁ = 0 at element 1, meaning a particle launched at (x₀, 0) never exceeds |x₀| there on later turns — the expected answer is exact and tune-independent, and 8 turns suffice.

The grid step is set to a/3.5, so the aperture falls between samples 3 and 4. The test asserts the result is 3a/3.5 and, critically, `< a`. **The old code returned 4a/3.5, an aperture larger than the physical aperture.** The `NaN`, `Inf` and `n_r < 2` branches are covered too.

Full suite: 28 pass, 0 fail (the 4 broken in `ESR Chromatic Functions` are pre-existing).

## Not addressed here

Issue #115 also surfaced that `Symplectic`'s default `n_steps = 1` gets β₁ wrong by +37% on that lattice, because `exact_bend!` handles only `Kn0` and a bend's K1 is applied as a thin kick. That belongs in BeamTracking, not here. With `n_steps = 10`, SciBmad and Bmad agree on both optics and aperture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
