### PR TITLE
Docs: scroll the sidebar to the page you just opened

### DIFF
--- a/docs/src/_static/sidebar-current.js
+++ b/docs/src/_static/sidebar-current.js
@@ -1,0 +1,52 @@
+// Keep the reader's place in the left sidebar across page loads.
+//
+// Furo renders the sidebar fresh on every page, so its scroll box always starts
+// at the top: click an entry halfway down a long menu and the next page shows
+// the menu from the beginning, with the page just opened somewhere below the
+// fold. Scroll the entry for the current page up to the top of the menu instead,
+// so it -- and the sections of it that Furo expands underneath -- are what the
+// reader sees.
+(function () {
+  // A little room above the entry, so it does not sit flush against the edge
+  // and the reader can tell that the menu is scrolled.
+  var MARGIN = 12;
+
+  function alignCurrentEntry() {
+    var box = document.querySelector(".sidebar-scroll");
+    if (!box) return;
+    // Furo marks the entry for the page being shown with `current-page`; take
+    // its own link, not the `current` links of the ancestors containing it.
+    var entry = box.querySelector(".current-page > a.current");
+    if (!entry) return;  // a page outside the toctree, e.g. the search results
+    var item = entry.closest("li");  // the entry together with its sections
+
+    var boxTop = box.getBoundingClientRect().top;
+    var itemRect = item.getBoundingClientRect();
+    // Nothing to do when the entry and all of its sections are already on
+    // screen -- which is the case for the first entries of the menu, and they
+    // should stay where they are rather than being nudged by the margin.
+    if (itemRect.top >= boxTop && itemRect.bottom <= boxTop + box.clientHeight) {
+      return;
+    }
+
+    // Work from the on-screen distance between entry and box, so the result
+    // does not depend on where the sidebar itself sits on the page. Scrolling
+    // past either end of the range is not possible, so an entry at the very
+    // bottom of the menu simply comes as close to the top as it can.
+    var target = box.scrollTop + entry.getBoundingClientRect().top - boxTop - MARGIN;
+
+    // `.sidebar-scroll` is `scroll-behavior: smooth`, which is right for a
+    // click but not here -- the menu should be in place when the page appears,
+    // not animate into it.
+    var behavior = box.style.scrollBehavior;
+    box.style.scrollBehavior = "auto";
+    box.scrollTop = target;
+    box.style.scrollBehavior = behavior;
+  }
+
+  if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", alignCurrentEntry);
+  } else {
+    alignCurrentEntry();
+  }
+})();

--- a/docs/src/conf.py
+++ b/docs/src/conf.py
@@ -331,7 +331,7 @@ html_theme_options = {
 html_title = 'SciBmad Documentation'
 html_static_path = ['_static']
 html_css_files = ['custom.css']
-html_js_files = ['topbar-github.js']
+html_js_files = ['topbar-github.js', 'sidebar-current.js']
 
 
 # -- Options for MyST --------------------------------------------------------


### PR DESCRIPTION
Fixes #118.

## Cause

The site uses Furo, which re-renders the left sidebar on every page load, so its scroll box (`.sidebar-scroll`) always starts at the top. Click an entry part-way down the menu and the next page arrives with the menu rewound to the beginning and the entry you just clicked somewhere below the fold. Neither Furo nor `conf.py` moves it.

## Fix

A small static script, `docs/src/_static/sidebar-current.js`, registered in `html_js_files`. On load it finds the current page's entry (`.current-page > a.current`) and scrolls the menu so that entry sits at the top, with a small margin.

Three details:

- Entries whose expanded sections are already fully on screen are left alone, so the top of the menu is not nudged on pages like Overview or Installation.
- Scrolling clamps at the ends of the range, so the last entry of the menu simply comes as close to the top as it can.
- `.sidebar-scroll` carries `scroll-behavior: smooth`, which is right for a click but not here; the script suspends it while setting `scrollTop`, so the menu is already in place when the page paints rather than animating into it.

## Verification

Served an existing build of the docs with the script in place, at a 1200x600 viewport where the menu overflows:

| page | result |
| --- | --- |
| Coordinates (mid-menu) | scrolled to 992, entry 12px from the top |
| Miscellaneous (last entry) | scrolled to the end of the range, as high as it goes |
| Installation (entry + sections already fit) | untouched |
| Overview (first entry) | untouched |
| Search (not in the toctree) | no-op, no error |

Visually, the Coordinates page now opens with **Coordinates** highlighted at the top of the menu and its sections listed under it.

Note: the docs were not fully rebuilt locally (that executes the Julia notebook pages); the change is confined to a static asset and `conf.py` compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
