### PR TITLE
CI: stop stale precompilation locks and cold caches from slowing the docs job

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -47,6 +47,7 @@ jobs:
   docs:
     name: Documentation
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       actions: write # needed to allow julia-actions/cache to proactively delete old caches that it has created
       contents: write
@@ -58,6 +59,15 @@ jobs:
         with:
           version: '1'
       - uses: julia-actions/cache@v3
+      - name: Clear stale precompilation locks
+        # A precompile process that dies leaves a `.ji.pidfile` behind in the
+        # depot, and `julia-actions/cache` then saves it and restores it into
+        # every later run. Loading a package whose lock is held blocks until the
+        # lock is finally declared stale, which costs ten minutes per Julia
+        # process -- see the two-hour build in PR #119. This runner is
+        # single-purpose and nothing is precompiling yet, so any lock sitting
+        # here is by definition left over from a run that is long gone.
+        run: find ~/.julia/compiled -name '*.pidfile' -print -delete || true
       - name: Configure doc environment
         shell: julia --project=docs --color=yes {0}
         run: |
@@ -70,6 +80,18 @@ jobs:
           python-version: '3.x'
       - name: Install Sphinx dependencies
         run: pip install -r docs/requirements.txt
+      - name: Precompile docs environment
+        # Every runnable page is executed by its own fresh IJulia kernel whose
+        # first cell is `using SciBmad`. Precompile the environment once here,
+        # where a failure is immediate and says what broke, instead of leaving
+        # each of those kernels to discover it and spend a 600 s
+        # `nb_execution_timeout` finding out -- ten pages of that is a two-hour
+        # red build whose log says only that a cell timed out.
+        shell: julia --project=docs --color=yes {0}
+        run: |
+          using Pkg
+          Pkg.precompile()
+          @time using SciBmad
       - name: Build documentation
         run: python docs/build.py
       - name: Deploy PR preview

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,16 @@ on:
       - main
     tags: ['*']
   pull_request:
+  # Keep main's Julia depot cache warm. A branch can read its own caches and
+  # main's, never another PR's, so a stale cache on main is paid for again by
+  # every new branch: the docs job spends ~13 minutes recompiling on its first
+  # run and ~6 minutes on every run after. Main's cache only refreshes when CI
+  # runs on main, which is why a floating `version: '1'` moving to a new Julia
+  # leaves every PR slow until someone next merges. Rebuild it on a schedule
+  # instead. Twice a week, comfortably inside the 7 days after which GitHub
+  # evicts a cache nothing has touched.
+  schedule:
+    - cron: '17 6 * * 1,4'
   workflow_dispatch:
 concurrency:
   # Skip intermediate builds: always.
@@ -14,6 +24,9 @@ concurrency:
 jobs:
   test:
     name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
+    # The scheduled run exists to refresh the docs cache; the test matrix keeps
+    # its own cache warm through ordinary pushes and PRs.
+    if: github.event_name != 'schedule'
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -92,6 +92,12 @@ jobs:
           using Pkg
           Pkg.precompile()
           @time using SciBmad
+      - name: Clear locks left by the precompile
+        # The same sweep again, and this is the one that protects the pages: the
+        # lock that broke PR #119 was created by a process dying during the big
+        # precompile, which is the step immediately above. Clearing only at the
+        # start of the job would leave that window open.
+        run: find ~/.julia/compiled -name '*.pidfile' -print -delete || true
       - name: Build documentation
         run: python docs/build.py
       - name: Deploy PR preview


### PR DESCRIPTION
Two problems with the `docs` job, both found while investigating the 2h11m failure on #119 that had nothing to do with that PR's diff.

## 1. A stale lock turns a slow build into a two-hour failure

A precompile process died during the initial precompilation and left a lock file in the depot:

```
Warning: attempting to remove probably stale pidfile
  path = "/home/runner/.julia/compiled/v1.13/SciBmad/3SAY4_e67vQ.ji.pidfile"
  @ FileWatching.Pidfile .../stdlib/v1.13/FileWatching/src/pidfile.jl:304
```

Every runnable page is executed by its own fresh IJulia kernel whose first cell is `using SciBmad`. Each kernel blocked on that lock rather than loading the cache, until the 600s `nb_execution_timeout` killed the cell. Ten pages, ten timeouts, 2h11m — and a log whose only complaint was `CellTimeoutError`.

`julia-actions/cache` then saved the depot with the lock still in it, so the next run restored the same trap.

- **Sweep `*.pidfile` locks after the depot cache is restored**, so a lock carried in by the cache cannot block the build.
- **Sweep again immediately before the pages run.** This is the one that protects the kernels: the lock that broke #119 was created by a process dying during the big precompile, which is the warm-up step below. Clearing only at the start of the job leaves that window open.
- **Precompile the docs environment before Sphinx starts.** A load that cannot work fails in one step that says why, instead of ten kernels each spending 600s finding out. The kernels then only ever load, never precompile.
- **Cap the job at 60 minutes.** GitHub's default is six hours.

## 2. Every new branch recompiles the whole docs environment

A branch can read its own caches and main's, never another PR's. Main's docs cache was last written on Sept 1, before CI moved to Julia 1.13, so every new branch pays the full compile on its first docs run:

| run | restored cache | `using SciBmad` | docs job |
| --- | --- | --- | --- |
| this branch, run 1 | `run_id=33523823426` — main, Sept 1 | 732s | 24m35s |
| this branch, run 2 | `run_id=34529511136` — this branch, run 1 | 4.4s | **5m53s** |

Main's cache only refreshes when CI runs on main, so today it recovers only when someone merges, and goes stale again the next time the floating `version: '1'` picks up a new Julia.

- **Run CI on main twice a week** (`cron: '17 6 * * 1,4'`), comfortably inside the 7 days after which GitHub evicts an untouched cache. The test matrix is excluded from the scheduled run — it keeps its own cache warm through ordinary pushes and PRs — and the deploy steps are already gated to `push` and `pull_request`, so a scheduled run builds the docs and touches nothing else.

Once main is warm, a new branch's first docs run should look like run 2 above rather than run 1.

## Notes

- `nb_execution_timeout` is left at 600s deliberately: with the warm-up in place a kernel's first `using` is a cache load, so the timeout goes back to guarding genuinely slow cells, which is what it is for.
- The `test` job is otherwise untouched. It uses a separate cache key (`job=test`) and was never affected.
- Unrelated pre-existing noise visible in these runs, not addressed here: a `Conda.jl` precompile error during `Pkg.precompile()`, and a `HostCPUFeatures` warning that the CPU info is out of date.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
